### PR TITLE
Fixed themeing issues with just-the-docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
-# gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
+gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
-# gem "just-the-docs", "0.5.3" # pinned to the current release
-gem "just-the-docs"        # always download the latest release
-
-gem 'jekyll-seo-tag'
+group :jekyll_plugins do
+  gem "just-the-docs" # pinned to the current release
+  gem "jekyll-remote-theme"
+  gem 'jekyll-seo-tag'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,11 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -59,6 +64,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.1.2)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass-embedded (1.63.6-arm64-darwin)
       google-protobuf (~> 3.23)
@@ -72,8 +78,10 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
+  jekyll-remote-theme
   jekyll-seo-tag
   just-the-docs
+  webrick
 
 BUNDLED WITH
    2.4.14


### PR DESCRIPTION
Needed to use remote_theme and jekyll-remote-theme to have the just-the-docs themes working when running through pages. 